### PR TITLE
In markdown, group by type, then by module

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -110,15 +110,16 @@ function formatMalformedEntries(changes: ChangeEntry[]): DataObject[] {
 	// Collect malformed on the top for easier fixing
 	const malformed = changes
 		.filter((c) => !c.valid())
-		.sort((a, b) => (a.pull_request < b.pull_request ? -1 : 1))
+		.map((c) => parsePullRequestNumberFromURL(c.pull_request))
+		.map((x) => parseInt(x))
+		.sort()
 
 	if (malformed.length > 0) {
 		body.push([{ [MARKDOWN_TYPE_TAG]: "[MALFORMED]" }])
 
 		const ul: string[] = []
-		for (const c of malformed) {
-			const prNum = parsePullRequestNumberFromURL(c.pull_request)
-			ul.push(`[#${prNum}](${c.pull_request})`)
+		for (const num of malformed) {
+			ul.push(`#${num}`)
 		}
 		body.push({ ul: ul.sort() })
 	}
@@ -132,8 +133,8 @@ function parsePullRequestNumberFromURL(prUrl: string): string {
 }
 
 function changeMardown(c: ChangeEntry): string {
-	const pr = parsePullRequestNumberFromURL(c.pull_request)
-	const lines = [`**[${c.module}]** ${c.description} [#${pr}](${pr})`]
+	const prNum = parsePullRequestNumberFromURL(c.pull_request)
+	const lines = [`**[${c.module}]** ${c.description} [#${prNum}](${c.pull_request})`]
 
 	if (c.note) {
 		lines.push(`${MARKDOWN_NOTE_PREFIX} ${c.note}`)

--- a/src/format.ts
+++ b/src/format.ts
@@ -77,10 +77,6 @@ export function formatMarkdown(milestone: string, changes: ChangeEntry[]): strin
 
 	const md = json2md(body)
 
-	// Workaround to omit excessive empty lines
-	// https://github.com/IonicaBizau/json2md/issues/53
-	// return fixLineBreaks(md)
-	console.log(md)
 	return md
 }
 
@@ -144,17 +140,4 @@ function changeMardown(c: ChangeEntry): string {
 	}
 
 	return lines.join("\n")
-}
-
-function fixLineBreaks(md: string): string {
-	const fixed = md
-		.split("\n")
-		// remove empty lines
-		.filter((s) => s.trim() != "")
-		// wrap subheaders with empty lines
-		.map((s) => (s.startsWith("#") ? `${s}\n` : s))
-		.join("\n")
-
-	// add empty line to the end
-	return fixed + "\n"
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -43,7 +43,7 @@ function groupByModuleAndType(acc: ChangesByModule, change: ChangeEntry) {
 			list = getTypeList("features")
 			break
 		default:
-			throw new Error("invalid type")
+			throw new Error("invalid type: " + change.type)
 	}
 
 	// add the change

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -13,7 +13,9 @@ const changes: ChangeEntry[] = [
 		type: "fix",
 		description: "d21",
 		pull_request: "https://github.com/ow/re/210",
-		note: "x",
+		note: `Grafana will be restarted.
+Now grafana using direct (proxy) type for deckhouse datasources (main, longterm, uncached), because direct(browse) datasources type is depreated now. And alerts don't work with direct data sources.
+Provisioning datasources from secret instead configmap. Deckhouse datasources need client certificates to connect to prometheus or trickter. Old cm leave to prevent mount error while terminating.`,
 	}),
 	new ChangeEntry({
 		module: "chrony",
@@ -67,7 +69,16 @@ cloud-provider-yandex:
       pull_request: https://github.com/ow/re/220
   fixes:
     - description: d21
-      note: x
+      note: >-
+        Grafana will be restarted.
+
+        Now grafana using direct (proxy) type for deckhouse datasources (main, longterm, uncached),
+        because direct(browse) datasources type is depreated now. And alerts don't work with direct
+        data sources.
+
+        Provisioning datasources from secret instead configmap. Deckhouse datasources need client
+        certificates to connect to prometheus or trickter. Old cm leave to prevent mount error while
+        terminating.
       pull_request: https://github.com/ow/re/210
     - description: d29
       pull_request: https://github.com/ow/re/290
@@ -106,7 +117,9 @@ describe("Markdown", () => {
 
  - **[chrony]** d11 [#110](https://github.com/ow/re/110)
  - **[cloud-provider-yandex]** d21 [#210](https://github.com/ow/re/210)
-    **NOTE!** x
+    **NOTE!** Grafana will be restarted.
+    Now grafana using direct (proxy) type for deckhouse datasources (main, longterm, uncached), because direct(browse) datasources type is depreated now. And alerts don't work with direct data sources.
+    Provisioning datasources from secret instead configmap. Deckhouse datasources need client certificates to connect to prometheus or trickter. Old cm leave to prevent mount error while terminating.
  - **[cloud-provider-yandex]** d29 [#290](https://github.com/ow/re/290)
  - **[kube-dns]** d48 [#480](https://github.com/ow/re/480)
 `

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -44,50 +44,38 @@ describe("Markdown", () => {
 
 	// This markdown formatting is implementation-dependant. The test only check that everything
 	// is in place.
-	const expected = `## Changelog v3.44.555
+	const expected = `# Changelog v3.44.555
 
-#### [MALFORMED]
+## [MALFORMED]
 
  - [#prm1](prm1)
  - [#prm2](prm2)
 
-#### one
+## Features
 
+ - **[one]** d12 [#pr12](pr12)
+ - **[two]** d22 [#pr22](pr22)
 
-**features**
+## Fixes
 
- - d12 [#pr12](pr12)
-
-**fixes**
-
- - d11 [#pr11](pr11)
-
-#### two
-
-
-**features**
-
- - d22 [#pr22](pr22)
-
-**fixes**
-
- - d21 [#pr21](pr21)
+ - **[one]** d11 [#pr11](pr11)
+ - **[two]** d21 [#pr21](pr21)
     **NOTE!** x
- - d28 [#pr28](pr28)
- - d29 [#pr29](pr29)
+ - **[two]** d28 [#pr28](pr28)
+ - **[two]** d29 [#pr29](pr29)
 `
-	test("has milestone header as h2", () => {
+	test("has milestone title as h1", () => {
 		const firstLine = md.split("\n")[0].trim()
-		expect(firstLine).toBe(`## Changelog v3.44.555`)
+		expect(firstLine).toBe(`# Changelog v3.44.555`)
 	})
 
-	test("formats module name as h4", () => {
+	test("formats type name as h2", () => {
 		const subheaders = md
 			.split("\n")
 			.map((s) => s.trim())
-			.filter((s) => s.startsWith("###"))
+			.filter((s) => s.startsWith("## "))
 
-		expect(subheaders).toStrictEqual(["#### [MALFORMED]", "#### one", "#### two"])
+		expect(subheaders).toStrictEqual(["## [MALFORMED]", "## Features", "## Fixes"])
 	})
 
 	test("formats right", () => {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -2,36 +2,79 @@ import { formatMarkdown, formatYaml } from "../src/format"
 import { ChangeEntry } from "../src/parse"
 
 const changes: ChangeEntry[] = [
-	new ChangeEntry({ module: "yyy", type: "", description: "dm2", pull_request: "prm2" }),
-	new ChangeEntry({ module: "two", type: "fix", description: "d21", pull_request: "pr21", note: "x" }),
-	new ChangeEntry({ module: "one", type: "feature", description: "d12", pull_request: "pr12" }),
-	new ChangeEntry({ module: "two", type: "feature", description: "d22", pull_request: "pr22" }),
-	new ChangeEntry({ module: "one", type: "fix", description: "d11", pull_request: "pr11" }),
-	new ChangeEntry({ module: "xxx", type: "", description: "dm1", pull_request: "prm1" }),
-	new ChangeEntry({ module: "two", type: "fix", description: "d28", pull_request: "pr28" }),
-	new ChangeEntry({ module: "two", type: "fix", description: "d29", pull_request: "pr29" }),
+	new ChangeEntry({
+		module: "yyy",
+		type: "",
+		description: "dm2",
+		pull_request: "https://github.com/ow/re/533",
+	}),
+	new ChangeEntry({
+		module: "cloud-provider-yandex",
+		type: "fix",
+		description: "d21",
+		pull_request: "https://github.com/ow/re/210",
+		note: "x",
+	}),
+	new ChangeEntry({
+		module: "chrony",
+		type: "feature",
+		description: "d12",
+		pull_request: "https://github.com/ow/re/120",
+	}),
+	new ChangeEntry({
+		module: "cloud-provider-yandex",
+		type: "feature",
+		description: "d22",
+		pull_request: "https://github.com/ow/re/220",
+	}),
+	new ChangeEntry({
+		module: "chrony",
+		type: "fix",
+		description: "d11",
+		pull_request: "https://github.com/ow/re/110",
+	}),
+	new ChangeEntry({
+		module: "xxx",
+		type: "",
+		description: "dm1",
+		pull_request: "https://github.com/ow/re/510",
+	}),
+	new ChangeEntry({
+		module: "kube-dns",
+		type: "fix",
+		description: "d48",
+		pull_request: "https://github.com/ow/re/480",
+	}),
+	new ChangeEntry({
+		module: "cloud-provider-yandex",
+		type: "fix",
+		description: "d29",
+		pull_request: "https://github.com/ow/re/290",
+	}),
 ]
 
 describe("YAML", () => {
-	const expected = `one:
+	const expected = `chrony:
   features:
     - description: d12
-      pull_request: pr12
+      pull_request: https://github.com/ow/re/120
   fixes:
     - description: d11
-      pull_request: pr11
-two:
+      pull_request: https://github.com/ow/re/110
+cloud-provider-yandex:
   features:
     - description: d22
-      pull_request: pr22
+      pull_request: https://github.com/ow/re/220
   fixes:
     - description: d21
       note: x
-      pull_request: pr21
-    - description: d28
-      pull_request: pr28
+      pull_request: https://github.com/ow/re/210
     - description: d29
-      pull_request: pr29
+      pull_request: https://github.com/ow/re/290
+kube-dns:
+  fixes:
+    - description: d48
+      pull_request: https://github.com/ow/re/480
 `
 	test("formats right", () => {
 		expect(formatYaml(changes)).toEqual(expected)
@@ -49,25 +92,25 @@ describe("Markdown", () => {
 ## [MALFORMED]
 
 
- - [#prm1](prm1)
- - [#prm2](prm2)
+ - #510
+ - #533
 
 ## Features
 
 
- - **[one]** d12 [#pr12](pr12)
- - **[two]** d22 [#pr22](pr22)
+ - **[chrony]** d12 [#120](https://github.com/ow/re/120)
+ - **[cloud-provider-yandex]** d22 [#220](https://github.com/ow/re/220)
 
 ## Fixes
 
 
- - **[one]** d11 [#pr11](pr11)
- - **[two]** d21 [#pr21](pr21)
+ - **[chrony]** d11 [#110](https://github.com/ow/re/110)
+ - **[cloud-provider-yandex]** d21 [#210](https://github.com/ow/re/210)
     **NOTE!** x
- - **[two]** d28 [#pr28](pr28)
- - **[two]** d29 [#pr29](pr29)
+ - **[cloud-provider-yandex]** d29 [#290](https://github.com/ow/re/290)
+ - **[kube-dns]** d48 [#480](https://github.com/ow/re/480)
 `
-	test("has milestone title as h1", () => {
+	test("has chrony title as h1", () => {
 		const firstLine = md.split("\n")[0].trim()
 		expect(firstLine).toBe(`# Changelog v3.44.555`)
 	})

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -48,15 +48,18 @@ describe("Markdown", () => {
 
 ## [MALFORMED]
 
+
  - [#prm1](prm1)
  - [#prm2](prm2)
 
 ## Features
 
+
  - **[one]** d12 [#pr12](pr12)
  - **[two]** d22 [#pr22](pr22)
 
 ## Fixes
+
 
  - **[one]** d11 [#pr11](pr11)
  - **[two]** d21 [#pr21](pr21)


### PR DESCRIPTION
- explicit failing on unknown type for valid changes
- regroup changes: type -> module
- add module name to change entry
