### PR TITLE
do not validate changelog on `impact_level: low`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -436,6 +436,10 @@ function main() {
                     core.setFailed("No pull request found in the GitHub context.");
                     return;
                 }
+                const impact_level = core.getInput("impact_level");
+                if (impact_level.toLowerCase() === "low") {
+                    return;
+                }
                 const validateInputs = {
                     pr: pr,
                     allowedSections: parseList(core.getInput("allowed_sections")),

--- a/dist/index.js
+++ b/dist/index.js
@@ -436,10 +436,6 @@ function main() {
                     core.setFailed("No pull request found in the GitHub context.");
                     return;
                 }
-                const impact_level = core.getInput("impact_level");
-                if (impact_level.toLowerCase() === "low") {
-                    return;
-                }
                 const validateInputs = {
                     pr: pr,
                     allowedSections: parseList(core.getInput("allowed_sections")),
@@ -628,6 +624,9 @@ class ChangeEntry extends ChangeContent {
     validate() {
         const errs = [];
         errs.push(...super.validate());
+        if (this.impact_level === exports.LEVEL_LOW) {
+            return errs;
+        }
         if (!!this.impact_level && !exports.knownLevels.has(this.impact_level)) {
             errs.push(`invalid impact level "${this.impact_level}"`);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -704,11 +704,11 @@ class ValidatorImpl {
         this.config = config;
     }
     validate(c) {
-        if (!this.config.has(c.section)) {
-            return new InvalidChangeEntry(c, [`unknown section "${c.section}"`]);
-        }
         if (c.impact_level === parse_1.LEVEL_LOW) {
             return c;
+        }
+        if (!this.config.has(c.section)) {
+            return new InvalidChangeEntry(c, [`unknown section "${c.section}"`]);
         }
         const forcedLevel = this.config.get(c.section);
         if (forcedLevel && forcedLevel != c.impact_level) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -623,9 +623,6 @@ class ChangeEntry extends ChangeContent {
     }
     validate() {
         const errs = [];
-        if (this.impact_level === exports.LEVEL_LOW) {
-            return errs;
-        }
         errs.push(...super.validate());
         if (!!this.impact_level && !exports.knownLevels.has(this.impact_level)) {
             errs.push(`invalid impact level "${this.impact_level}"`);
@@ -704,6 +701,9 @@ class ValidatorImpl {
         this.config = config;
     }
     validate(c) {
+        if (c.impact_level === parse_1.LEVEL_LOW) {
+            return c;
+        }
         if (!this.config.has(c.section)) {
             return new InvalidChangeEntry(c, [`unknown section "${c.section}"`]);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -623,6 +623,9 @@ class ChangeEntry extends ChangeContent {
     }
     validate() {
         const errs = [];
+        if (this.impact_level === exports.LEVEL_LOW) {
+            return errs;
+        }
         errs.push(...super.validate());
         if (!!this.impact_level && !exports.knownLevels.has(this.impact_level)) {
             errs.push(`invalid impact level "${this.impact_level}"`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -704,11 +704,11 @@ class ValidatorImpl {
         this.config = config;
     }
     validate(c) {
-        if (c.impact_level === parse_1.LEVEL_LOW) {
-            return c;
-        }
         if (!this.config.has(c.section)) {
             return new InvalidChangeEntry(c, [`unknown section "${c.section}"`]);
+        }
+        if (c.impact_level === parse_1.LEVEL_LOW) {
+            return c;
         }
         const forcedLevel = this.config.get(c.section);
         if (forcedLevel && forcedLevel != c.impact_level) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -623,10 +623,10 @@ class ChangeEntry extends ChangeContent {
     }
     validate() {
         const errs = [];
-        errs.push(...super.validate());
         if (this.impact_level === exports.LEVEL_LOW) {
             return errs;
         }
+        errs.push(...super.validate());
         if (!!this.impact_level && !exports.knownLevels.has(this.impact_level)) {
             errs.push(`invalid impact level "${this.impact_level}"`);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,13 @@ async function main() {
 				core.setFailed("No pull request found in the GitHub context.")
 				return
 			}
+
+			// skip validation if impact level is low
+			const impact_level = core.getInput("impact_level")
+			if (impact_level.toLowerCase() === "low") {
+				return
+			}
+
 			const validateInputs: ValidateInput = {
 				pr: pr,
 				allowedSections: parseList(core.getInput("allowed_sections")),

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,6 @@ async function main() {
 				core.setFailed("No pull request found in the GitHub context.")
 				return
 			}
-
-			// skip validation if impact level is low
-			const impact_level = core.getInput("impact_level")
-			if (impact_level.toLowerCase() === "low") {
-				return
-			}
-
 			const validateInputs: ValidateInput = {
 				pr: pr,
 				allowedSections: parseList(core.getInput("allowed_sections")),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -204,11 +204,6 @@ export class ChangeEntry extends ChangeContent {
 	validate(): string[] {
 		const errs: string[] = []
 
-		// skip validation if impact level is low
-		if (this.impact_level === LEVEL_LOW) {
-			return errs
-		}
-
 		errs.push(...super.validate())
 
 		// validate level

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -204,6 +204,11 @@ export class ChangeEntry extends ChangeContent {
 	validate(): string[] {
 		const errs: string[] = []
 
+		// skip validation if impact level is low
+		if (this.impact_level === LEVEL_LOW) {
+			return errs
+		}
+
 		errs.push(...super.validate())
 
 		// validate level

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -204,12 +204,12 @@ export class ChangeEntry extends ChangeContent {
 	validate(): string[] {
 		const errs: string[] = []
 
-		errs.push(...super.validate())
-
 		// skip validation if impact level is low
 		if (this.impact_level === LEVEL_LOW) {
 			return errs
 		}
+
+		errs.push(...super.validate())
 
 		// validate level
 		if (!!this.impact_level && !knownLevels.has(this.impact_level)) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -206,6 +206,11 @@ export class ChangeEntry extends ChangeContent {
 
 		errs.push(...super.validate())
 
+		// skip validation if impact level is low
+		if (this.impact_level === LEVEL_LOW) {
+			return errs
+		}
+
 		// validate level
 		if (!!this.impact_level && !knownLevels.has(this.impact_level)) {
 			errs.push(`invalid impact level "${this.impact_level}"`)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -32,15 +32,14 @@ export class ValidatorImpl implements Validator {
 
 	validate(c: ChangeEntry): ChangeEntry {
 
-		if (!this.config.has(c.section)) {
-			return new InvalidChangeEntry(c, [`unknown section "${c.section}"`])
-		}
-
 		// skip validation if impact level is low
 		if (c.impact_level === LEVEL_LOW) {
 			return c
 		}
 
+		if (!this.config.has(c.section)) {
+			return new InvalidChangeEntry(c, [`unknown section "${c.section}"`])
+		}
 		const forcedLevel = this.config.get(c.section)
 		if (forcedLevel && forcedLevel != c.impact_level) {
 			const cc = new ChangeEntry(c) // a way to copy the change object

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -32,14 +32,15 @@ export class ValidatorImpl implements Validator {
 
 	validate(c: ChangeEntry): ChangeEntry {
 
+		if (!this.config.has(c.section)) {
+			return new InvalidChangeEntry(c, [`unknown section "${c.section}"`])
+		}
+
 		// skip validation if impact level is low
 		if (c.impact_level === LEVEL_LOW) {
 			return c
 		}
 
-		if (!this.config.has(c.section)) {
-			return new InvalidChangeEntry(c, [`unknown section "${c.section}"`])
-		}
 		const forcedLevel = this.config.get(c.section)
 		if (forcedLevel && forcedLevel != c.impact_level) {
 			const cc = new ChangeEntry(c) // a way to copy the change object

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -31,7 +31,6 @@ export class ValidatorImpl implements Validator {
 	constructor(private config: Map<string, string>) {}
 
 	validate(c: ChangeEntry): ChangeEntry {
-
 		// skip validation if impact level is low
 		if (c.impact_level === LEVEL_LOW) {
 			return c

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,4 +1,4 @@
-import { ChangeEntry, ChangeEntryOpts, knownLevels } from "./parse"
+import { ChangeEntry, ChangeEntryOpts, knownLevels, LEVEL_LOW } from "./parse"
 
 export function getValidator(allowedSections: string[] = []): ValidatorImpl | NoopValidator {
 	if (allowedSections.length === 0) {
@@ -31,6 +31,12 @@ export class ValidatorImpl implements Validator {
 	constructor(private config: Map<string, string>) {}
 
 	validate(c: ChangeEntry): ChangeEntry {
+
+		// skip validation if impact level is low
+		if (c.impact_level === LEVEL_LOW) {
+			return c
+		}
+
 		if (!this.config.has(c.section)) {
 			return new InvalidChangeEntry(c, [`unknown section "${c.section}"`])
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->

Do not validate required fields on `impact_level: low`.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->

`impact_level: low` prevents adding changelog entry to the final changelog. So it is an internal note and no need to bother with validity of such changelog entry.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->

Validation is successfully passed for `impact_level: low` changelog entry even if required fields are incorrect or absent.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
impact_level: low
summary: changelog improvements
section: unknown-section
type: xs-fix
```

```changes
impact_level: low
summary: 
section: 
type:
```

