### PR TITLE
add type `docs`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -270,6 +270,7 @@ function getYAMLSorter() {
     const yamlFieldSorter = {
         features: 1,
         fixes: 2,
+        docs: 3,
         summary: 1,
         pull_request: 2,
         impact: 3,
@@ -313,6 +314,9 @@ function groupByModuleAndType(acc, change) {
         case parse_1.TYPE_FEATURE:
             listOf("features").push(cc);
             break;
+        case parse_1.TYPE_DOCS:
+            listOf("docs").push(cc);
+            break;
         case parse_1.TYPE_CHORE:
             break;
         default:
@@ -337,6 +341,7 @@ function formatMarkdown(milestone, changes) {
     add("Know before update", collectImpact);
     add("Features", (cs) => collectChanges(cs, parse_1.TYPE_FEATURE));
     add("Fixes", (cs) => collectChanges(cs, parse_1.TYPE_FIX));
+    add("Docs", (cs) => collectChanges(cs, parse_1.TYPE_DOCS));
     add("Chore", (cs) => collectChanges(cs, parse_1.TYPE_CHORE));
     return (0, json2md_1.default)(body);
 }
@@ -503,7 +508,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ChangeEntry = exports.ChangeContent = exports.parseChangesBlocks = exports.knownLevels = exports.LEVEL_DEFAULT = exports.LEVEL_LOW = exports.LEVEL_HIGH = exports.TYPE_CHORE = exports.TYPE_FEATURE = exports.TYPE_FIX = exports.parseChangeEntries = exports.collectChangelog = void 0;
+exports.ChangeEntry = exports.ChangeContent = exports.parseChangesBlocks = exports.knownLevels = exports.LEVEL_DEFAULT = exports.LEVEL_LOW = exports.LEVEL_HIGH = exports.TYPE_DOCS = exports.TYPE_CHORE = exports.TYPE_FEATURE = exports.TYPE_FIX = exports.parseChangeEntries = exports.collectChangelog = void 0;
 const yaml = __importStar(__nccwpck_require__(1917));
 const marked_1 = __nccwpck_require__(5741);
 function collectChangelog(pulls, validator) {
@@ -552,7 +557,8 @@ function* generateEntries(changesBlocks) {
 exports.TYPE_FIX = "fix";
 exports.TYPE_FEATURE = "feature";
 exports.TYPE_CHORE = "chore";
-const knownTypes = new Set([exports.TYPE_FIX, exports.TYPE_FEATURE, exports.TYPE_CHORE]);
+exports.TYPE_DOCS = "docs";
+const knownTypes = new Set([exports.TYPE_FIX, exports.TYPE_FEATURE, exports.TYPE_CHORE, exports.TYPE_DOCS]);
 exports.LEVEL_HIGH = "high";
 exports.LEVEL_LOW = "low";
 exports.LEVEL_DEFAULT = "default";

--- a/dist/index.js
+++ b/dist/index.js
@@ -270,7 +270,6 @@ function getYAMLSorter() {
     const yamlFieldSorter = {
         features: 1,
         fixes: 2,
-        docs: 3,
         summary: 1,
         pull_request: 2,
         impact: 3,
@@ -315,7 +314,6 @@ function groupByModuleAndType(acc, change) {
             listOf("features").push(cc);
             break;
         case parse_1.TYPE_DOCS:
-            listOf("docs").push(cc);
             break;
         case parse_1.TYPE_CHORE:
             break;

--- a/dist/index.js
+++ b/dist/index.js
@@ -339,7 +339,6 @@ function formatMarkdown(milestone, changes) {
     add("Know before update", collectImpact);
     add("Features", (cs) => collectChanges(cs, parse_1.TYPE_FEATURE));
     add("Fixes", (cs) => collectChanges(cs, parse_1.TYPE_FIX));
-    add("Docs", (cs) => collectChanges(cs, parse_1.TYPE_DOCS));
     add("Chore", (cs) => collectChanges(cs, parse_1.TYPE_CHORE));
     return (0, json2md_1.default)(body);
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -112,7 +112,6 @@ export function formatMarkdown(milestone: string, changes: ChangeEntry[]): strin
 	add("Know before update", collectImpact)
 	add("Features", (cs) => collectChanges(cs, TYPE_FEATURE))
 	add("Fixes", (cs) => collectChanges(cs, TYPE_FIX))
-	add("Docs", (cs) => collectChanges(cs, TYPE_DOCS))
 	add("Chore", (cs) => collectChanges(cs, TYPE_CHORE))
 
 	return json2md(body)

--- a/src/format.ts
+++ b/src/format.ts
@@ -10,6 +10,7 @@ import {
 	TYPE_CHORE,
 	TYPE_FEATURE,
 	TYPE_FIX,
+	TYPE_DOCS,
 } from "./parse"
 
 // sorts YAML keys
@@ -18,6 +19,7 @@ function getYAMLSorter() {
 	const yamlFieldSorter = {
 		features: 1,
 		fixes: 2,
+		docs: 3,
 
 		summary: 1,
 		pull_request: 2,
@@ -75,6 +77,9 @@ function groupByModuleAndType(acc: ChangesByModule, change: ChangeEntry) {
 		case TYPE_FEATURE:
 			listOf("features").push(cc)
 			break
+		case TYPE_DOCS:
+			listOf("docs").push(cc)
+			break
 		case TYPE_CHORE:
 			// Noop for yaml
 			break
@@ -108,6 +113,7 @@ export function formatMarkdown(milestone: string, changes: ChangeEntry[]): strin
 	add("Know before update", collectImpact)
 	add("Features", (cs) => collectChanges(cs, TYPE_FEATURE))
 	add("Fixes", (cs) => collectChanges(cs, TYPE_FIX))
+	add("Docs", (cs) => collectChanges(cs, TYPE_DOCS))
 	add("Chore", (cs) => collectChanges(cs, TYPE_CHORE))
 
 	return json2md(body)

--- a/src/format.ts
+++ b/src/format.ts
@@ -19,7 +19,6 @@ function getYAMLSorter() {
 	const yamlFieldSorter = {
 		features: 1,
 		fixes: 2,
-		docs: 3,
 
 		summary: 1,
 		pull_request: 2,
@@ -78,7 +77,7 @@ function groupByModuleAndType(acc: ChangesByModule, change: ChangeEntry) {
 			listOf("features").push(cc)
 			break
 		case TYPE_DOCS:
-			listOf("docs").push(cc)
+			// Noop for yaml
 			break
 		case TYPE_CHORE:
 			// Noop for yaml

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -12,6 +12,7 @@ export interface ChangesByModule {
 export interface ModuleChanges {
 	fixes?: ChangeContent[]
 	features?: ChangeContent[]
+	docs?: ChangeContent[]
 }
 
 /**

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -12,7 +12,6 @@ export interface ChangesByModule {
 export interface ModuleChanges {
 	fixes?: ChangeContent[]
 	features?: ChangeContent[]
-	docs?: ChangeContent[]
 }
 
 /**

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -90,7 +90,9 @@ function* generateEntries(changesBlocks: string[]): Generator<unknown> {
 export const TYPE_FIX = "fix"
 export const TYPE_FEATURE = "feature"
 export const TYPE_CHORE = "chore"
-const knownTypes = new Set([TYPE_FIX, TYPE_FEATURE, TYPE_CHORE])
+export const TYPE_DOCS = "docs"
+
+const knownTypes = new Set([TYPE_FIX, TYPE_FEATURE, TYPE_CHORE, TYPE_DOCS])
 
 export const LEVEL_HIGH = "high"
 export const LEVEL_LOW = "low" // logically the same as chore, probably


### PR DESCRIPTION
## Description
<!---
  Describe your changes with technical details.
-->
Add type `docs` to changelog.

## Why do we need it, and what problem does it solve?
<!---
  Tell a story about the problem we've faced, why we've decided to fix it
  and what effect users will get after merging. Add links if applicable.
-->
To stop docs from appearing in changelog.

## What is the expected result?
<!---
  Describe steps to reproduce the expected result.
  What ACTION(s) to take to ensure the problem is gone.
-->
1. Type `docs` can be used in changelog entry field.
2. PRs with aforementioned type will not appear in changelog for milestone.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Add one or more changelog entries to present your changes to end users.

  Changelog entry fields description:
  - `section` - a project scope in the kebab-case (See CONTRIBUTING.md#scope for the list).
  - `type` - one of the following: fix, feature, chore
  - `summary` - a ONE-LINE description on how change affects users.
  - `impact_level` - Optional field: set to 'low' to exclude entry from changelog.
  - `impact` - Optional field: multiline message on what user should know in the first place, i.e. restarts, breaking changes, deprecated fields, etc. Requires `impact_level: high`.

  /!\ See CONTRIBUTING.md for more details. /!\

  Example 1. Significant message at the beginning of the changelog:

section: disks
type: feat
summary: "Disks serials are based on uid now."
impact_level: high
impact: |
  Disk serial is now uid-based.

  Using /dev/disk/by-serial/ is not supported anymore.


  Example 2. Chore change (not in the Changelog):

section: ci
type: chore
summary: "Update checkout and github-script action versions."
impact_level: low


  Example 3. Regular entry in the Changelog:

section: vm
type: feature
summary: "virtualMachineClassName field is now required."

-->

```changes
section: ci
type: docs
summary: add docs docs docs
```
