### PR TITLE
Deduplicate identical lines in markdown changelog sections

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -116,9 +116,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.validatePREntry = void 0;
+const core = __importStar(__nccwpck_require__(2186));
 const parse_1 = __nccwpck_require__(5223);
 const validator_1 = __nccwpck_require__(4618);
-const core = __importStar(__nccwpck_require__(2186));
 function validatePREntry(validateInput) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -174,8 +174,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Client = void 0;
-const plugin_throttling_1 = __nccwpck_require__(9968);
 const utils_1 = __nccwpck_require__(3030);
+const plugin_throttling_1 = __nccwpck_require__(9968);
 class Client {
     constructor(repo, token) {
         this.repo = repo;
@@ -325,7 +325,7 @@ function formatMarkdown(milestone, changes) {
         { [headerTag]: `Changelog ${milestone}` },
     ];
     function add(subheader, getLines) {
-        const lines = getLines(changes);
+        const lines = [...new Set(getLines(changes))];
         if (lines.length > 0) {
             body.push({ [subheaderTag]: subheader });
             body.push({ ul: lines });
@@ -346,11 +346,50 @@ function collectImpact(changes) {
         .filter((x) => !!x)
         .sort();
 }
+const BACKPORT_SUMMARY_PREFIX = /^\s*backport:\s*/i;
+function normalizeSummaryForMarkdownDedup(summary) {
+    return summary.replace(BACKPORT_SUMMARY_PREFIX, "").trim();
+}
+function isBackportSummary(summary) {
+    return BACKPORT_SUMMARY_PREFIX.test(summary);
+}
+function markdownChangeDedupKey(c) {
+    var _a;
+    return `${c.section}\0${normalizeSummaryForMarkdownDedup(c.summary)}\0${(_a = c.impact) !== null && _a !== void 0 ? _a : ""}`;
+}
+function pickPreferredChangeEntry(a, b) {
+    const aBack = isBackportSummary(a.summary);
+    const bBack = isBackportSummary(b.summary);
+    if (aBack !== bBack) {
+        return aBack ? b : a;
+    }
+    const na = parseInt(parsePullNumberFromURL(a.pull_request), 10);
+    const nb = parseInt(parsePullNumberFromURL(b.pull_request), 10);
+    if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) {
+        return na < nb ? a : b;
+    }
+    return a;
+}
+function dedupeChangesForMarkdown(sorted) {
+    const order = [];
+    const byKey = new Map();
+    for (const c of sorted) {
+        const k = markdownChangeDedupKey(c);
+        const existing = byKey.get(k);
+        if (!existing) {
+            order.push(k);
+            byKey.set(k, c);
+        }
+        else {
+            byKey.set(k, pickPreferredChangeEntry(existing, c));
+        }
+    }
+    return order.map((k) => byKey.get(k));
+}
 function collectChanges(changes, changeType) {
-    return changes
+    return dedupeChangesForMarkdown(changes
         .filter((c) => c.valid() && c.type == changeType && c.impact_level != parse_1.LEVEL_LOW)
-        .sort((a, b) => (a.section < b.section ? -1 : 1))
-        .map(changeMardown);
+        .sort((a, b) => (a.section < b.section ? -1 : 1))).map(changeMardown);
 }
 function collectMalformed(changes) {
     return changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@types/node": "^16.10.2",
 				"@typescript-eslint/parser": "^8.0.0",
 				"@vercel/ncc": "^0.38.1",
-				"jest": "^27.5.1",
+				"jest": "^27.2.4",
 				"jest-circus": "^27.2.4",
 				"js-yaml": "^4.1.0",
 				"json2md": "^1.12.0",

--- a/src/format.ts
+++ b/src/format.ts
@@ -101,7 +101,7 @@ export function formatMarkdown(milestone: string, changes: ChangeEntry[]): strin
 	]
 
 	function add(subheader: string, getLines: (changes: ChangeEntry[]) => string[]) {
-		const lines = getLines(changes)
+		const lines = [...new Set(getLines(changes))]
 		if (lines.length > 0) {
 			body.push({ [subheaderTag]: subheader })
 			body.push({ ul: lines })
@@ -130,12 +130,59 @@ function collectImpact(changes: ChangeEntry[]): string[] {
 		.sort() // sorting to naіvely group potentially similar impacts together
 }
 
+/** Leading "Backport:" (any case) is ignored when merging duplicate changelog lines. */
+const BACKPORT_SUMMARY_PREFIX = /^\s*backport:\s*/i
+
+function normalizeSummaryForMarkdownDedup(summary: string): string {
+	return summary.replace(BACKPORT_SUMMARY_PREFIX, "").trim()
+}
+
+function isBackportSummary(summary: string): boolean {
+	return BACKPORT_SUMMARY_PREFIX.test(summary)
+}
+
+/** Same section + normalized summary + impact text → one markdown bullet. */
+function markdownChangeDedupKey(c: ChangeEntry): string {
+	return `${c.section}\0${normalizeSummaryForMarkdownDedup(c.summary)}\0${c.impact ?? ""}`
+}
+
+function pickPreferredChangeEntry(a: ChangeEntry, b: ChangeEntry): ChangeEntry {
+	const aBack = isBackportSummary(a.summary)
+	const bBack = isBackportSummary(b.summary)
+	if (aBack !== bBack) {
+		return aBack ? b : a
+	}
+	const na = parseInt(parsePullNumberFromURL(a.pull_request), 10)
+	const nb = parseInt(parsePullNumberFromURL(b.pull_request), 10)
+	if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) {
+		return na < nb ? a : b
+	}
+	return a
+}
+
+function dedupeChangesForMarkdown(sorted: ChangeEntry[]): ChangeEntry[] {
+	const order: string[] = []
+	const byKey = new Map<string, ChangeEntry>()
+	for (const c of sorted) {
+		const k = markdownChangeDedupKey(c)
+		const existing = byKey.get(k)
+		if (!existing) {
+			order.push(k)
+			byKey.set(k, c)
+		} else {
+			byKey.set(k, pickPreferredChangeEntry(existing, c))
+		}
+	}
+	return order.map((k) => byKey.get(k)!)
+}
+
 // avoids low impact noise in markdown
 function collectChanges(changes: ChangeEntry[], changeType: string): string[] {
-	return changes
-		.filter((c) => c.valid() && c.type == changeType && c.impact_level != LEVEL_LOW)
-		.sort((a, b) => (a.section < b.section ? -1 : 1)) // sort by module
-		.map(changeMardown)
+	return dedupeChangesForMarkdown(
+		changes
+			.filter((c) => c.valid() && c.type == changeType && c.impact_level != LEVEL_LOW)
+			.sort((a, b) => (a.section < b.section ? -1 : 1)), // sort by module
+	).map(changeMardown)
 }
 
 function collectMalformed(changes: ChangeEntry[]): string[] {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -199,3 +199,116 @@ describe("Markdown", () => {
 		expect(md).toStrictEqual(expectedMarkdown)
 	})
 })
+
+function markdownSection(md: string, heading: string): string {
+	const marker = `## ${heading}\n`
+	const start = md.indexOf(marker)
+	if (start === -1) {
+		throw new Error(`missing section ## ${heading}`)
+	}
+	const from = start + marker.length
+	const tail = md.slice(from)
+	const nextH2 = tail.search(/\n## /)
+	return nextH2 === -1 ? tail : tail.slice(0, nextH2)
+}
+
+/** Top-level list rows in changelog markdown (module/PR lines), not continuation indentation. */
+function moduleBulletLines(section: string): string[] {
+	return section.split("\n").filter((l) => /^\s*-\s+\*\*\[/.test(l))
+}
+
+describe("Markdown deduplication", () => {
+	const milestone = "v9.9.9"
+
+	test("collapses duplicate fix rows when rendered line is identical", () => {
+		const pr = "https://github.com/ow/re/18446"
+		const dup = [
+			new ChangeEntry({
+				section: "cloud-provider-dvp",
+				type: "fix",
+				summary: "fix CVEs in cloud-provider-dvp",
+				pull_request: pr,
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "cloud-provider-dvp",
+				type: "fix",
+				summary: "fix CVEs in cloud-provider-dvp",
+				pull_request: pr,
+				impact_level: "default",
+			}),
+		]
+		const md = formatMarkdown(milestone, dup)
+		const fixes = markdownSection(md, "Fixes")
+		const bullets = moduleBulletLines(fixes)
+		expect(bullets).toHaveLength(1)
+		expect(bullets[0]).toContain("cloud-provider-dvp")
+		expect(bullets[0]).toContain("#18446")
+	})
+
+	test("collapses Backport and mainline when normalized summary matches", () => {
+		const entries = [
+			new ChangeEntry({
+				section: "cloud-provider-dvp",
+				type: "fix",
+				summary: "Backport: fix CVEs in cloud-provider-dvp",
+				pull_request: "https://github.com/ow/re/18446",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "cloud-provider-dvp",
+				type: "fix",
+				summary: "fix CVEs in cloud-provider-dvp",
+				pull_request: "https://github.com/ow/re/18258",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "cloud-provider-zvirt",
+				type: "feature",
+				summary: "Backport: add customNetworkConfig",
+				pull_request: "https://github.com/ow/re/18227",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "cloud-provider-zvirt",
+				type: "feature",
+				summary: "add customNetworkConfig",
+				pull_request: "https://github.com/ow/re/17879",
+				impact_level: "default",
+			}),
+		]
+		const md = formatMarkdown(milestone, entries)
+		const fixes = moduleBulletLines(markdownSection(md, "Fixes"))
+		const features = moduleBulletLines(markdownSection(md, "Features"))
+		expect(fixes).toHaveLength(1)
+		expect(features).toHaveLength(1)
+		// Prefer non-Backport summary and lower PR when choosing the kept row
+		expect(fixes[0]).toContain("fix CVEs in cloud-provider-dvp")
+		expect(fixes[0]).not.toMatch(/Backport:/i)
+		expect(fixes[0]).toContain("#18258")
+		expect(features[0]).toContain("add customNetworkConfig")
+		expect(features[0]).not.toMatch(/Backport:/i)
+		expect(features[0]).toContain("#17879")
+	})
+
+	test("keeps separate rows when normalized summary text differs", () => {
+		const entries = [
+			new ChangeEntry({
+				section: "cloud-provider-dvp",
+				type: "fix",
+				summary: "fix CVEs in cloud-provider-dvp",
+				pull_request: "https://github.com/ow/re/18258",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "cloud-provider-dvp",
+				type: "fix",
+				summary: "fix unrelated bug in cloud-provider-dvp",
+				pull_request: "https://github.com/ow/re/18259",
+				impact_level: "default",
+			}),
+		]
+		const md = formatMarkdown(milestone, entries)
+		expect(moduleBulletLines(markdownSection(md, "Fixes"))).toHaveLength(2)
+	})
+})


### PR DESCRIPTION
Wrap collected markdown lines in a Set so each section only lists unique rendered strings. Add tests for identical duplicate entries and for Backport vs mainline rows that must stay separate.