### PR TITLE
Deduplicate identical lines in markdown changelog sections

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -284,9 +284,17 @@ function formatYaml(changes) {
         forceQuotes: false,
         quotingType: "'",
     };
-    const body = changes
-        .filter((c) => c.valid())
-        .reduce(groupByModuleAndType, {});
+    const valid = changes.filter((c) => c.valid());
+    const bySection = (a, b) => (a.section < b.section ? -1 : 1);
+    const fixes = dedupeChangesForYaml(valid.filter((c) => c.type === parse_1.TYPE_FIX).sort(bySection));
+    const features = dedupeChangesForYaml(valid.filter((c) => c.type === parse_1.TYPE_FEATURE).sort(bySection));
+    const body = {};
+    for (const c of fixes) {
+        groupByModuleAndType(body, c);
+    }
+    for (const c of features) {
+        groupByModuleAndType(body, c);
+    }
     return yaml.dump(body, opts);
 }
 exports.formatYaml = formatYaml;
@@ -411,6 +419,9 @@ function dedupeChangesForMarkdown(sorted) {
         }
         return { primary, prNumbers, prUrlByNumber: urls };
     });
+}
+function dedupeChangesForYaml(sorted) {
+    return dedupeChangesForMarkdown(sorted).map((m) => m.primary);
 }
 function formatChangeMarkdownLine(primary, prNumbers, prUrlByNumber) {
     var _a;

--- a/dist/index.js
+++ b/dist/index.js
@@ -375,21 +375,65 @@ function dedupeChangesForMarkdown(sorted) {
     const byKey = new Map();
     for (const c of sorted) {
         const k = markdownChangeDedupKey(c);
+        const n = parseInt(parsePullNumberFromURL(c.pull_request), 10);
         const existing = byKey.get(k);
         if (!existing) {
             order.push(k);
-            byKey.set(k, c);
+            const urls = new Map();
+            if (Number.isFinite(n)) {
+                urls.set(n, c.pull_request);
+            }
+            byKey.set(k, {
+                primary: c,
+                nums: new Set(Number.isFinite(n) ? [n] : []),
+                urls,
+            });
         }
         else {
-            byKey.set(k, pickPreferredChangeEntry(existing, c));
+            if (Number.isFinite(n)) {
+                existing.nums.add(n);
+                existing.urls.set(n, c.pull_request);
+            }
+            existing.primary = pickPreferredChangeEntry(existing.primary, c);
         }
     }
-    return order.map((k) => byKey.get(k));
+    return order.map((k) => {
+        const { primary, nums, urls } = byKey.get(k);
+        let prNumbers = [...nums];
+        if (prNumbers.length === 0) {
+            const fallback = parseInt(parsePullNumberFromURL(primary.pull_request), 10);
+            if (Number.isFinite(fallback)) {
+                prNumbers = [fallback];
+                if (!urls.has(fallback)) {
+                    urls.set(fallback, primary.pull_request);
+                }
+            }
+        }
+        return { primary, prNumbers, prUrlByNumber: urls };
+    });
+}
+function formatChangeMarkdownLine(primary, prNumbers, prUrlByNumber) {
+    var _a;
+    let prlink;
+    if (prNumbers.length === 0) {
+        const prNum = parsePullNumberFromURL(primary.pull_request);
+        prlink = `[#${prNum}](${primary.pull_request})`;
+    }
+    else {
+        const chosen = Math.min(...prNumbers);
+        const prUrl = (_a = prUrlByNumber.get(chosen)) !== null && _a !== void 0 ? _a : primary.pull_request;
+        prlink = `[#${chosen}](${prUrl})`;
+    }
+    const line = `**[${primary.section}]** ${primary.summary} ${prlink}`;
+    if (primary.impact) {
+        return line + "\n" + primary.impact;
+    }
+    return line;
 }
 function collectChanges(changes, changeType) {
     return dedupeChangesForMarkdown(changes
         .filter((c) => c.valid() && c.type == changeType && c.impact_level != parse_1.LEVEL_LOW)
-        .sort((a, b) => (a.section < b.section ? -1 : 1))).map(changeMardown);
+        .sort((a, b) => (a.section < b.section ? -1 : 1))).map(({ primary, prNumbers, prUrlByNumber }) => formatChangeMarkdownLine(primary, prNumbers, prUrlByNumber));
 }
 function collectMalformed(changes) {
     return changes
@@ -404,15 +448,6 @@ function collectMalformed(changes) {
 function parsePullNumberFromURL(prUrl) {
     const parts = prUrl.split("/");
     return parts[parts.length - 1];
-}
-function changeMardown(c) {
-    const prNum = parsePullNumberFromURL(c.pull_request);
-    const prlink = `[#${prNum}](${c.pull_request})`;
-    const line = `**[${c.section}]** ${c.summary} ${prlink}`;
-    if (c.impact) {
-        return line + "\n" + c.impact;
-    }
-    return line;
 }
 
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -46,10 +46,18 @@ export function formatYaml(changes: ChangeEntry[]): string {
 		quotingType: "'",
 	} as yaml.DumpOptions
 
-	// create the map from only valid entries:  module -> fix/feature -> change[]
-	const body = changes
-		.filter((c) => c.valid()) //
-		.reduce(groupByModuleAndType, {})
+	const valid = changes.filter((c) => c.valid())
+	const bySection = (a: ChangeEntry, b: ChangeEntry) => (a.section < b.section ? -1 : 1)
+	const fixes = dedupeChangesForYaml(valid.filter((c) => c.type === TYPE_FIX).sort(bySection))
+	const features = dedupeChangesForYaml(valid.filter((c) => c.type === TYPE_FEATURE).sort(bySection))
+
+	const body: ChangesByModule = {}
+	for (const c of fixes) {
+		groupByModuleAndType(body, c)
+	}
+	for (const c of features) {
+		groupByModuleAndType(body, c)
+	}
 
 	return yaml.dump(body, opts)
 }
@@ -169,10 +177,7 @@ interface MergedChangeForMarkdown {
 
 function dedupeChangesForMarkdown(sorted: ChangeEntry[]): MergedChangeForMarkdown[] {
 	const order: string[] = []
-	const byKey = new Map<
-		string,
-		{ primary: ChangeEntry; nums: Set<number>; urls: Map<number, string> }
-	>()
+	const byKey = new Map<string, { primary: ChangeEntry; nums: Set<number>; urls: Map<number, string> }>()
 	for (const c of sorted) {
 		const k = markdownChangeDedupKey(c)
 		const n = parseInt(parsePullNumberFromURL(c.pull_request), 10)
@@ -210,6 +215,11 @@ function dedupeChangesForMarkdown(sorted: ChangeEntry[]): MergedChangeForMarkdow
 		}
 		return { primary, prNumbers, prUrlByNumber: urls }
 	})
+}
+
+/** Same key as markdown: section + normalized summary + impact; prefers non-backport, lower PR #. */
+function dedupeChangesForYaml(sorted: ChangeEntry[]): ChangeEntry[] {
+	return dedupeChangesForMarkdown(sorted).map((m) => m.primary)
 }
 
 /** When several PRs match the same line, link the one with the smallest PR number */

--- a/src/format.ts
+++ b/src/format.ts
@@ -160,20 +160,79 @@ function pickPreferredChangeEntry(a: ChangeEntry, b: ChangeEntry): ChangeEntry {
 	return a
 }
 
-function dedupeChangesForMarkdown(sorted: ChangeEntry[]): ChangeEntry[] {
+interface MergedChangeForMarkdown {
+	primary: ChangeEntry
+	/** Unique PR numbers in this group */
+	prNumbers: number[]
+	prUrlByNumber: Map<number, string>
+}
+
+function dedupeChangesForMarkdown(sorted: ChangeEntry[]): MergedChangeForMarkdown[] {
 	const order: string[] = []
-	const byKey = new Map<string, ChangeEntry>()
+	const byKey = new Map<
+		string,
+		{ primary: ChangeEntry; nums: Set<number>; urls: Map<number, string> }
+	>()
 	for (const c of sorted) {
 		const k = markdownChangeDedupKey(c)
+		const n = parseInt(parsePullNumberFromURL(c.pull_request), 10)
 		const existing = byKey.get(k)
 		if (!existing) {
 			order.push(k)
-			byKey.set(k, c)
+			const urls = new Map<number, string>()
+			if (Number.isFinite(n)) {
+				urls.set(n, c.pull_request)
+			}
+			byKey.set(k, {
+				primary: c,
+				nums: new Set(Number.isFinite(n) ? [n] : []),
+				urls,
+			})
 		} else {
-			byKey.set(k, pickPreferredChangeEntry(existing, c))
+			if (Number.isFinite(n)) {
+				existing.nums.add(n)
+				existing.urls.set(n, c.pull_request)
+			}
+			existing.primary = pickPreferredChangeEntry(existing.primary, c)
 		}
 	}
-	return order.map((k) => byKey.get(k)!)
+	return order.map((k) => {
+		const { primary, nums, urls } = byKey.get(k)!
+		let prNumbers = [...nums]
+		if (prNumbers.length === 0) {
+			const fallback = parseInt(parsePullNumberFromURL(primary.pull_request), 10)
+			if (Number.isFinite(fallback)) {
+				prNumbers = [fallback]
+				if (!urls.has(fallback)) {
+					urls.set(fallback, primary.pull_request)
+				}
+			}
+		}
+		return { primary, prNumbers, prUrlByNumber: urls }
+	})
+}
+
+/** When several PRs match the same line, link the one with the smallest PR number */
+function formatChangeMarkdownLine(
+	primary: ChangeEntry,
+	prNumbers: number[],
+	prUrlByNumber: Map<number, string>,
+): string {
+	let prlink: string
+	if (prNumbers.length === 0) {
+		const prNum = parsePullNumberFromURL(primary.pull_request)
+		prlink = `[#${prNum}](${primary.pull_request})`
+	} else {
+		const chosen = Math.min(...prNumbers)
+		const prUrl = prUrlByNumber.get(chosen) ?? primary.pull_request
+		prlink = `[#${chosen}](${prUrl})`
+	}
+	const line = `**[${primary.section}]** ${primary.summary} ${prlink}`
+
+	if (primary.impact) {
+		return line + "\n" + primary.impact
+	}
+	return line
 }
 
 // avoids low impact noise in markdown
@@ -182,7 +241,9 @@ function collectChanges(changes: ChangeEntry[], changeType: string): string[] {
 		changes
 			.filter((c) => c.valid() && c.type == changeType && c.impact_level != LEVEL_LOW)
 			.sort((a, b) => (a.section < b.section ? -1 : 1)), // sort by module
-	).map(changeMardown)
+	).map(({ primary, prNumbers, prUrlByNumber }) =>
+		formatChangeMarkdownLine(primary, prNumbers, prUrlByNumber),
+	)
 }
 
 function collectMalformed(changes: ChangeEntry[]): string[] {
@@ -199,16 +260,4 @@ function collectMalformed(changes: ChangeEntry[]): string[] {
 function parsePullNumberFromURL(prUrl: string): string {
 	const parts = prUrl.split("/")
 	return parts[parts.length - 1]
-}
-
-function changeMardown(c: ChangeEntry): string {
-	const prNum = parsePullNumberFromURL(c.pull_request)
-
-	const prlink = `[#${prNum}](${c.pull_request})`
-	const line = `**[${c.section}]** ${c.summary} ${prlink}`
-
-	if (c.impact) {
-		return line + "\n" + c.impact
-	}
-	return line
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -285,10 +285,53 @@ describe("Markdown deduplication", () => {
 		// Prefer non-Backport summary and lower PR when choosing the kept row
 		expect(fixes[0]).toContain("fix CVEs in cloud-provider-dvp")
 		expect(fixes[0]).not.toMatch(/Backport:/i)
-		expect(fixes[0]).toContain("#18258")
+		expect(fixes[0]).toContain("[#18258](https://github.com/ow/re/18258)")
+		expect(fixes[0]).not.toContain("18446")
 		expect(features[0]).toContain("add customNetworkConfig")
 		expect(features[0]).not.toMatch(/Backport:/i)
-		expect(features[0]).toContain("#17879")
+		expect(features[0]).toContain("[#17879](https://github.com/ow/re/17879)")
+		expect(features[0]).not.toContain("18227")
+	})
+
+	test("merged duplicate descriptions link the smallest PR number", () => {
+		const summary = "same change text"
+		const entries = [
+			new ChangeEntry({
+				section: "mod",
+				type: "fix",
+				summary,
+				pull_request: "https://github.com/ow/re/18349",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "mod",
+				type: "fix",
+				summary,
+				pull_request: "https://github.com/ow/re/18350",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "mod",
+				type: "fix",
+				summary,
+				pull_request: "https://github.com/ow/re/18355",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "mod",
+				type: "fix",
+				summary,
+				pull_request: "https://github.com/ow/re/18348",
+				impact_level: "default",
+			}),
+		]
+		const md = formatMarkdown(milestone, entries)
+		const fixes = moduleBulletLines(markdownSection(md, "Fixes"))
+		expect(fixes).toHaveLength(1)
+		expect(fixes[0]).toContain("[#18348](https://github.com/ow/re/18348)")
+		expect(fixes[0]).not.toContain("18349")
+		expect(fixes[0]).not.toContain("18350")
+		expect(fixes[0]).not.toContain("18355")
 	})
 
 	test("keeps separate rows when normalized summary text differs", () => {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs"
+import * as yaml from "js-yaml"
 import { formatMarkdown, formatYaml } from "../src/format"
 import { ChangeEntry } from "../src/parse"
 
@@ -166,6 +167,149 @@ describe("YAML", () => {
 
 	test("formats right", () => {
 		expect(formatYaml(changes)).toEqual(expectedYAML)
+	})
+})
+
+type YamlModule = {
+	features?: Array<{ summary: string; pull_request: string; impact?: string }>
+	fixes?: Array<{ summary: string; pull_request: string; impact?: string }>
+}
+
+describe("YAML deduplication", () => {
+	test("merges duplicate fixes with same section, summary, and impact; keeps smaller PR number", () => {
+		const list = [
+			new ChangeEntry({
+				section: "alpha",
+				type: "fix",
+				summary: "duplicate fix text",
+				pull_request: "https://github.com/ow/re/900",
+				impact_level: "low",
+			}),
+			new ChangeEntry({
+				section: "alpha",
+				type: "fix",
+				summary: "duplicate fix text",
+				pull_request: "https://github.com/ow/re/100",
+				impact_level: "low",
+			}),
+		]
+		const doc = yaml.load(formatYaml(list)) as Record<string, YamlModule>
+		expect(doc.alpha.fixes).toHaveLength(1)
+		expect(doc.alpha.fixes![0].pull_request).toBe("https://github.com/ow/re/100")
+		expect(doc.alpha.fixes![0].summary).toBe("duplicate fix text")
+	})
+
+	test("merges duplicate features the same way", () => {
+		const list = [
+			new ChangeEntry({
+				section: "beta",
+				type: "feature",
+				summary: "same feature",
+				pull_request: "https://github.com/ow/re/50",
+				impact_level: "default",
+			}),
+			new ChangeEntry({
+				section: "beta",
+				type: "feature",
+				summary: "same feature",
+				pull_request: "https://github.com/ow/re/10",
+				impact_level: "default",
+			}),
+		]
+		const doc = yaml.load(formatYaml(list)) as Record<string, YamlModule>
+		expect(doc.beta.features).toHaveLength(1)
+		expect(doc.beta.features![0].pull_request).toBe("https://github.com/ow/re/10")
+	})
+
+	test("prefers non-backport summary over Backport: … for the same normalized text", () => {
+		const list = [
+			new ChangeEntry({
+				section: "gamma",
+				type: "fix",
+				summary: "Backport: shared description",
+				pull_request: "https://github.com/ow/re/1",
+				impact_level: "low",
+			}),
+			new ChangeEntry({
+				section: "gamma",
+				type: "fix",
+				summary: "shared description",
+				pull_request: "https://github.com/ow/re/999",
+				impact_level: "low",
+			}),
+		]
+		const doc = yaml.load(formatYaml(list)) as Record<string, YamlModule>
+		expect(doc.gamma.fixes).toHaveLength(1)
+		expect(doc.gamma.fixes![0].summary).toBe("shared description")
+		expect(doc.gamma.fixes![0].pull_request).toBe("https://github.com/ow/re/999")
+	})
+
+	test("does not merge same summary in different sections", () => {
+		const list = [
+			new ChangeEntry({
+				section: "m-a",
+				type: "fix",
+				summary: "shared",
+				pull_request: "https://github.com/ow/re/1",
+				impact_level: "low",
+			}),
+			new ChangeEntry({
+				section: "m-b",
+				type: "fix",
+				summary: "shared",
+				pull_request: "https://github.com/ow/re/2",
+				impact_level: "low",
+			}),
+		]
+		const doc = yaml.load(formatYaml(list)) as Record<string, YamlModule>
+		expect(doc["m-a"].fixes).toHaveLength(1)
+		expect(doc["m-b"].fixes).toHaveLength(1)
+		expect(doc["m-a"].fixes![0].pull_request).not.toBe(doc["m-b"].fixes![0].pull_request)
+	})
+
+	test("does not merge fix and feature with the same summary in one section", () => {
+		const list = [
+			new ChangeEntry({
+				section: "delta",
+				type: "fix",
+				summary: "same line",
+				pull_request: "https://github.com/ow/re/1",
+				impact_level: "low",
+			}),
+			new ChangeEntry({
+				section: "delta",
+				type: "feature",
+				summary: "same line",
+				pull_request: "https://github.com/ow/re/2",
+				impact_level: "default",
+			}),
+		]
+		const doc = yaml.load(formatYaml(list)) as Record<string, YamlModule>
+		expect(doc.delta.fixes).toHaveLength(1)
+		expect(doc.delta.features).toHaveLength(1)
+	})
+
+	test("does not merge when impact text differs", () => {
+		const list = [
+			new ChangeEntry({
+				section: "eps",
+				type: "fix",
+				summary: "same summary",
+				pull_request: "https://github.com/ow/re/1",
+				impact_level: "high",
+				impact: "first impact",
+			}),
+			new ChangeEntry({
+				section: "eps",
+				type: "fix",
+				summary: "same summary",
+				pull_request: "https://github.com/ow/re/2",
+				impact_level: "high",
+				impact: "second impact",
+			}),
+		]
+		const doc = yaml.load(formatYaml(list)) as Record<string, YamlModule>
+		expect(doc.eps.fixes).toHaveLength(2)
 	})
 })
 


### PR DESCRIPTION
Wrap collected markdown lines in a Set so each section only lists unique rendered strings. Add tests for identical duplicate entries and for Backport vs mainline rows that must stay separate.